### PR TITLE
Return object

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,13 @@ module.exports = function (name, cb) {
 			}
 		}
 
-		cb(null, 'name: ' + name + ' \nversion: ' + version + ' \ndescription: ' + description + ' \nlicense: ' + license + ' \nhomepage: ' + homepage + ' \nauthor: ' + author_name);
+		cb(null, {
+			name: name,
+			version: version,
+			description: description,
+			license: license,
+			homepage: homepage,
+			author: author_name
+		});
 	});
 };

--- a/test.js
+++ b/test.js
@@ -3,9 +3,13 @@ var assert = require('assert');
 var info = require('./index');
 
 it('should get the latest info of a package', function (cb) {
-	info('pageres', function (err, version) {
+	info('pageres', function (err, info) {
 		assert(!err, err);
-		assert(version);
+		assert(info);
+		['name', 'version', 'description', 'license', 'homepage', 'author']
+			.forEach(function (field) {
+				assert(typeof info[field] == 'string', 'has ' + field);
+			});
 		cb();
 	});
 });


### PR DESCRIPTION
Since this module returns a string, the only way to use it is to parse that string, which isn't even a JSON.

This PR makes it return an object instead.