### PR TITLE
manage when a package is not found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "package-info",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "package-info",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "dependencies": {
         "got": "^12.5.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 'use strict'
 
+import { errorMonitor } from 'events'
 import got, { RequestError } from 'got'
+import { exit } from 'process'
 import registryUrl from 'registry-url'
 
 interface DistTags {
@@ -32,34 +34,34 @@ interface Package {
 
 const fetchData = async (request: string): Promise<Package> => {
 	let name = ''
-    let version = ''
-    let description = ''
-    let license = ''
-    let homepage = ''
-    let author = ''
+  let version = ''
+  let description = ''
+  let license = ''
+  let homepage = ''
+  let author = ''
   try {
     const dataParsed: PackageData = await got(request).json()
     name = dataParsed.name
 
-     version = dataParsed['dist-tags'].latest
+    version = dataParsed['dist-tags'].latest
     description = dataParsed.description
     license = dataParsed.license
     homepage = dataParsed.homepage || ''
-     author =
+    author =
 		dataParsed.author?.name ||
 		dataParsed.maintainers?.map(({ name }) => name).join(', ') ||
 		''
+
+    return {
+      name,
+      version,
+      description,
+      license,
+      homepage,
+      author
+    }
   } catch (error) {
-
-  }
-
-  return {
-    name,
-    version,
-    description,
-    license,
-    homepage,
-    author
+    throw (new Error('Error on retrieve the package'))
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,58 +1,68 @@
-"use strict";
+'use strict'
 
-import got from 'got';
-import registryUrl from 'registry-url';
+import got, { RequestError } from 'got'
+import registryUrl from 'registry-url'
 
-type DistTags = {
-    latest: string
+interface DistTags {
+  latest: string
 }
 
-type Author = {
-    name: string
+interface Author {
+  name: string
 }
 
-type PackageData = {
-    name: string
-    'dist-tags': DistTags
-    description: string
-    license: string
-    homepage?: string
-    author?: Author
-    maintainers: Author[]
+interface PackageData {
+  name: string
+  'dist-tags': DistTags
+  description: string
+  license: string
+  homepage?: string
+  author?: Author
+  maintainers: Author[]
 }
 
-type Package = {
-    name: string
-    version: string
-    description: string
-    license: string
-    homepage: string
-    author: string
+interface Package {
+  name: string
+  version: string
+  description: string
+  license: string
+  homepage: string
+  author: string
 }
 
 const fetchData = async (request: string): Promise<Package> => {
-	const dataParsed: PackageData = await got(request).json();
+	let name = ''
+    let version = ''
+    let description = ''
+    let license = ''
+    let homepage = ''
+    let author = ''
+  try {
+    const dataParsed: PackageData = await got(request).json()
+    name = dataParsed.name
 
-	const name = dataParsed.name;
-	const version = dataParsed["dist-tags"].latest;
-	const description = dataParsed.description;
-	const license = dataParsed.license;
-	const homepage = dataParsed.homepage || '';
-	const author =
+     version = dataParsed['dist-tags'].latest
+    description = dataParsed.description
+    license = dataParsed.license
+    homepage = dataParsed.homepage || ''
+     author =
 		dataParsed.author?.name ||
 		dataParsed.maintainers?.map(({ name }) => name).join(', ') ||
-		'';
+		''
+  } catch (error) {
 
-	return {
-		name,
-		version,
-		description,
-		license,
-		homepage,
-		author,
-	};
-};
+  }
 
-export default async function info(name: string) {
-	return fetchData(registryUrl() + name.toLowerCase());
+  return {
+    name,
+    version,
+    description,
+    license,
+    homepage,
+    author
+  }
+}
+
+export default async function info (name: string) {
+  return await fetchData(registryUrl() + name.toLowerCase())
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,13 +32,22 @@ interface Package {
   author: string
 }
 
-const fetchData = async (request: string): Promise<Package> => {
-	let name = ''
+type PackageResult = {
+    success: true
+    data: Package
+} | {
+	success: false
+    error: string
+}
+
+const fetchData = async (request: string): Promise<PackageResult> => {
+  let name = ''
   let version = ''
   let description = ''
   let license = ''
   let homepage = ''
   let author = ''
+
   try {
     const dataParsed: PackageData = await got(request).json()
     name = dataParsed.name
@@ -53,18 +62,29 @@ const fetchData = async (request: string): Promise<Package> => {
 		''
 
     return {
-      name,
-      version,
-      description,
-      license,
-      homepage,
-      author
+        success: true,
+        data: {
+            name,
+            version,
+            description,
+            license,
+            homepage,
+            author
+        }
     }
   } catch (error) {
-    throw (new Error('Error on retrieve the package'))
+      return {
+        success: false,
+        error: 'Error on retrieve package information'
+      }
   }
 }
 
 export default async function info (name: string) {
-  return await fetchData(registryUrl() + name.toLowerCase())
+  	const result = await fetchData(registryUrl() + name.toLowerCase())
+	if (result.success) {
+		return result.data
+	}
+
+	return result.error
 }


### PR DESCRIPTION
At the moment when a package is not found the tool returns a bad error, with this PR now it returns package data or an error string, 
It should fix #26 
